### PR TITLE
Fix invalid spring boot version

### DIFF
--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -5,7 +5,8 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0</version>
+        <!-- Use a stable Spring Boot version -->
+        <version>3.2.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.mvp</groupId>


### PR DESCRIPTION
## Summary
- pin Spring Boot to stable 3.2.5 instead of a non-existent 3.5.0

## Testing
- `mvn -q -f product-service/pom.xml test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2c7a0d5083259a3e473c6d6ab6d8